### PR TITLE
Fixed deserialization to also work with binary serializers

### DIFF
--- a/src/Foundatio.Redis/Extensions/RedisValueExtensions.cs
+++ b/src/Foundatio.Redis/Extensions/RedisValueExtensions.cs
@@ -18,7 +18,7 @@ namespace Foundatio.Redis {
             else if (type == TypeHelper.NullableBoolType || type.IsNullableNumeric())
                 value = redisValue.IsNull ? default(T) : (T)Convert.ChangeType(redisValue, Nullable.GetUnderlyingType(type));
             else
-                return serializer.DeserializeAsync<T>(redisValue.ToString());
+                return serializer.DeserializeAsync<T>((byte[])redisValue);
 
             return Task.FromResult(value);
         }

--- a/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
+++ b/src/Foundatio.Redis/Messaging/RedisMessageBus.cs
@@ -40,7 +40,7 @@ namespace Foundatio.Messaging {
             _logger.Trace("OnMessage({channel})", channel);
             MessageBusData message;
             try {
-                message = await _serializer.DeserializeAsync<MessageBusData>((string)value).AnyContext();
+                message = await _serializer.DeserializeAsync<MessageBusData>((byte[])value).AnyContext();
             } catch (Exception ex) {
                 _logger.Warn(ex, "OnMessage({0}) Error deserializing messsage: {1}", channel, ex.Message);
                 return;


### PR DESCRIPTION
There is no need to force the RedisValue to a string. It will work
regardless with json serializers, but casting it to a string breaks
binary serializers. It hits two different deserialize overloads in 
the serializer extentions in Foundatio.